### PR TITLE
HDDS-2929. Implement ofs://: temp directory mount

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+CORE-SITE.XML_fs.ofs.impl=org.apache.hadoop.fs.ozone.RootedOzoneFileSystem
 CORE-SITE.XML_fs.o3fs.impl=org.apache.hadoop.fs.ozone.OzoneFileSystem
 
 OZONE-SITE.XML_ozone.om.address=om

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -42,7 +42,6 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType;
 import org.apache.hadoop.ozone.security.acl.OzoneAclConfig;
-import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.After;
 import org.junit.Assert;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -51,7 +51,6 @@ import org.junit.rules.Timeout;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -658,16 +658,11 @@ public class TestRootedOzoneFileSystem {
     Assert.assertNotNull(vol);
 
     // Begin test
-    String username = "";
-    try {
-      username = UserGroupInformation.getCurrentUser().getUserName();
-    } catch (IOException ex) {
-      Assert.fail("Unable to get current user name.");
-    }
+    String hashedUsername = OFSPath.getTempMountBucketName(null);
 
     // Expect failure since temp bucket for current user is not created yet
     try {
-      vol.getBucket(username);
+      vol.getBucket(hashedUsername);
     } catch (OMException ex) {
       // Expect BUCKET_NOT_FOUND
       if (!ex.getResult().equals(BUCKET_NOT_FOUND)) {
@@ -686,7 +681,7 @@ public class TestRootedOzoneFileSystem {
 //    }
 
     // Verify temp bucket creation
-    OzoneBucket bucket = vol.getBucket(username);
+    OzoneBucket bucket = vol.getBucket(hashedUsername);
     Assert.assertNotNull(bucket);
     // Verify dir1 creation
     FileStatus[] fileStatuses = fs.listStatus(new Path("/tmp/"));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.fs.ozone;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -672,12 +673,9 @@ public class TestRootedOzoneFileSystem {
     // Write under /tmp/, OFS will create the temp bucket if not exist
     fs.mkdirs(new Path("/tmp/dir1"));
 
-//    FSDataOutputStream stream = fs.create(new Path("/tmp/dir1/file1"));
-//    stream.write(1);
-
-//    try (FSDataOutputStream stream = fs.create(new Path("/tmp/dir1/file1"))) {
-//      stream.write(1);
-//    }
+    try (FSDataOutputStream stream = ofs.create(new Path("/tmp/dir1/file1"))) {
+      stream.write(1);
+    }
 
     // Verify temp bucket creation
     OzoneBucket bucket = vol.getBucket(hashedUsername);
@@ -687,6 +685,12 @@ public class TestRootedOzoneFileSystem {
     Assert.assertEquals(1, fileStatuses.length);
     Assert.assertEquals(
         "/tmp/dir1", fileStatuses[0].getPath().toUri().getPath());
+    // Verify file1 creation
+    FileStatus[] fileStatusesInDir1 =
+        fs.listStatus(new Path("/tmp/dir1"));
+    Assert.assertEquals(1, fileStatusesInDir1.length);
+    Assert.assertEquals("/tmp/dir1/file1",
+        fileStatusesInDir1[0].getPath().toUri().getPath());
   }
 
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.fs.ozone;
 
+import com.sun.tools.javac.util.List;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
@@ -28,12 +29,20 @@ import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.client.VolumeArgs;
+import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType;
+import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType;
+import org.apache.hadoop.ozone.security.acl.OzoneAclConfig;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.After;
 import org.junit.Assert;
@@ -51,8 +60,10 @@ import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import static org.apache.hadoop.fs.ozone.Constants.LISTING_PAGE_SIZE;
+import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCKET_NOT_FOUND;
 
 /**
  * Ozone file system tests that are not covered by contract tests.
@@ -63,10 +74,11 @@ public class TestRootedOzoneFileSystem {
   @Rule
   public Timeout globalTimeout = new Timeout(300_000);
 
-  private static MiniOzoneCluster cluster = null;
-  private static FileSystem fs;
-  private static RootedOzoneFileSystem ofs;
-  private static ObjectStore objectStore;
+  private OzoneConfiguration conf;
+  private MiniOzoneCluster cluster = null;
+  private FileSystem fs;
+  private RootedOzoneFileSystem ofs;
+  private ObjectStore objectStore;
 
   private String volumeName;
   private String bucketName;
@@ -76,7 +88,7 @@ public class TestRootedOzoneFileSystem {
 
   @Before
   public void init() throws Exception {
-    OzoneConfiguration conf = new OzoneConfiguration();
+    conf = new OzoneConfiguration();
     cluster = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(3)
         .build();
@@ -113,12 +125,12 @@ public class TestRootedOzoneFileSystem {
 
   @Test
   public void testOzoneFsServiceLoader() throws IOException {
-    OzoneConfiguration conf = new OzoneConfiguration();
+    OzoneConfiguration cfg = new OzoneConfiguration();
     // Note: FileSystem#loadFileSystems won't load OFS class due to META-INF
     //  hence this workaround.
-    conf.set("fs.ofs.impl", "org.apache.hadoop.fs.ozone.RootedOzoneFileSystem");
+    cfg.set("fs.ofs.impl", "org.apache.hadoop.fs.ozone.RootedOzoneFileSystem");
     Assert.assertEquals(
-        FileSystem.getFileSystemClass(OzoneConsts.OZONE_OFS_URI_SCHEME, conf),
+        FileSystem.getFileSystemClass(OzoneConsts.OZONE_OFS_URI_SCHEME, cfg),
         RootedOzoneFileSystem.class);
   }
 
@@ -614,6 +626,73 @@ public class TestRootedOzoneFileSystem {
     // listStatus("/")
     Path root = new Path(OZONE_URI_DELIMITER);
     listStatusCheckHelper(root);
+  }
+
+  /**
+   * OFS: Test /tmp mount behavior.
+   */
+  @Test
+  public void testTempMount() throws Exception {
+    // Prep
+    // Use ClientProtocol to pass in volume ACL, ObjectStore won't do it
+    ClientProtocol proxy = objectStore.getClientProxy();
+    // Get default acl rights for user
+    OzoneAclConfig aclConfig = conf.getObject(OzoneAclConfig.class);
+    ACLType userRights = aclConfig.getUserDefaultRights();
+    // Construct ACL for world access
+    OzoneAcl aclWorldAccess = new OzoneAcl(ACLIdentityType.WORLD, "",
+        userRights, ACCESS);
+    // Construct VolumeArgs
+    VolumeArgs volumeArgs = new VolumeArgs.Builder()
+        .setAcls(new ArrayList<>(List.of(aclWorldAccess))).build();
+    // Sanity check
+    Assert.assertNull(volumeArgs.getOwner());
+    Assert.assertNull(volumeArgs.getAdmin());
+    Assert.assertNull(volumeArgs.getQuota());
+    Assert.assertEquals(0, volumeArgs.getMetadata().size());
+    Assert.assertEquals(1, volumeArgs.getAcls().size());
+    // Create volume "tmp" with world access. allow non-admin to create buckets
+    proxy.createVolume(OFSPath.OFS_MOUNT_TMP_VOLUMENAME, volumeArgs);
+
+    OzoneVolume vol = objectStore.getVolume(OFSPath.OFS_MOUNT_TMP_VOLUMENAME);
+    Assert.assertNotNull(vol);
+
+    // Begin test
+    String username = "";
+    try {
+      username = UserGroupInformation.getCurrentUser().getUserName();
+    } catch (IOException ex) {
+      Assert.fail("Unable to get current user name.");
+    }
+
+    // Expect failure since temp bucket for current user is not created yet
+    try {
+      vol.getBucket(username);
+    } catch (OMException ex) {
+      // Expect BUCKET_NOT_FOUND
+      if (!ex.getResult().equals(BUCKET_NOT_FOUND)) {
+        Assert.fail("Temp bucket for current user shouldn't have been created");
+      }
+    }
+
+    // Write under /tmp/, OFS will create the temp bucket if not exist
+    fs.mkdirs(new Path("/tmp/dir1"));
+
+//    FSDataOutputStream stream = fs.create(new Path("/tmp/dir1/file1"));
+//    stream.write(1);
+
+//    try (FSDataOutputStream stream = fs.create(new Path("/tmp/dir1/file1"))) {
+//      stream.write(1);
+//    }
+
+    // Verify temp bucket creation
+    OzoneBucket bucket = vol.getBucket(username);
+    Assert.assertNotNull(bucket);
+    // Verify dir1 creation
+    FileStatus[] fileStatuses = fs.listStatus(new Path("/tmp/"));
+    Assert.assertEquals(1, fileStatuses.length);
+    Assert.assertEquals(
+        "/tmp/dir1", fileStatuses[0].getPath().toUri().getPath());
   }
 
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.fs.ozone;
 
-import com.sun.tools.javac.util.List;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
@@ -52,6 +51,8 @@ import org.junit.rules.Timeout;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -643,7 +644,7 @@ public class TestRootedOzoneFileSystem {
         userRights, ACCESS);
     // Construct VolumeArgs
     VolumeArgs volumeArgs = new VolumeArgs.Builder()
-        .setAcls(new ArrayList<>(List.of(aclWorldAccess))).build();
+        .setAcls(Collections.singletonList(aclWorldAccess)).build();
     // Sanity check
     Assert.assertNull(volumeArgs.getOwner());
     Assert.assertNull(volumeArgs.getAdmin());

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -291,7 +291,7 @@ public class BasicRootedOzoneClientAdapterImpl
     OFSPath ofsPath = new OFSPath(pathStr);
     String key = ofsPath.getKeyName();
     try {
-      OzoneBucket bucket = getBucket(ofsPath, false);
+      OzoneBucket bucket = getBucket(ofsPath, recursive);
       OzoneOutputStream ozoneOutputStream = bucket.createFile(
           key, 0, replicationType, replicationFactor, overWrite, recursive);
       return new OzoneFSOutputStream(ozoneOutputStream.getOutputStream());

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -212,7 +212,9 @@ public class BasicRootedOzoneClientAdapterImpl
     try {
       bucket = proxy.getBucketDetails(volumeStr, bucketStr);
     } catch (OMException ex) {
-      if (createIfNotExist) {
+      // Note: always create bucket if volumeStr matches "tmp" so -put works
+      if (createIfNotExist ||
+          volumeStr.equals(OFSPath.OFS_MOUNT_TMP_VOLUMENAME)) {
         // Note: getBucketDetails always throws BUCKET_NOT_FOUND, even if
         // the volume doesn't exist.
         if (ex.getResult().equals(BUCKET_NOT_FOUND)) {

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OFSPath.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OFSPath.java
@@ -17,9 +17,13 @@
  */
 package org.apache.hadoop.fs.ozone;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.yetus.audience.InterfaceStability;
+
+import java.io.IOException;
 import java.util.StringTokenizer;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
@@ -40,7 +44,7 @@ class OFSPath {
    * /vol1/buc2/dir3/key4  vol1           buc2           (empty)      dir3/key4
    * /vol1/buc2            vol1           buc2           (empty)      (empty)
    * /vol1                 vol1           (empty)        (empty)      (empty)
-   * /tmp/dir3/key4        tempVolume     tempBucket     tmp          dir3/key4
+   * /tmp/dir3/key4        tmp            <username>     tmp          dir3/key4
    *
    * Note the leading '/' doesn't matter.
    */
@@ -48,7 +52,11 @@ class OFSPath {
   private String bucketName = "";
   private String mountName = "";
   private String keyName = "";
-  private static final String OFS_MOUNT_NAME_TMP = "tmp";
+  @VisibleForTesting
+  static final String OFS_MOUNT_NAME_TMP = "tmp";
+  // Hard-code the volume name to tmp for the first implementation
+  @VisibleForTesting
+  static final String OFS_MOUNT_TMP_VOLUMENAME = "tmp";
 
   OFSPath(Path path) {
     String pathStr = path.toUri().getPath();
@@ -67,10 +75,9 @@ class OFSPath {
       // TODO: Compare a keyword list instead for future expansion.
       if (firstToken.equals(OFS_MOUNT_NAME_TMP)) {
         mountName = firstToken;
-        // TODO: Retrieve volume and bucket of the mount from user protobuf.
-        //  Leave them hard-coded just for now. Will be addressed in HDDS-2929
-        volumeName = "tempVolume";
-        bucketName = "tempBucket";
+        // Future: retrieve volume and bucket from UserVolumeInfo
+        volumeName = OFS_MOUNT_TMP_VOLUMENAME;
+        bucketName = getTempMountBucketName();
       } else if (numToken >= 2) {
         // Regular volume and bucket path
         volumeName = firstToken;
@@ -157,5 +164,13 @@ class OFSPath {
    */
   public boolean isVolume() {
     return this.getBucketName().isEmpty() && !this.getVolumeName().isEmpty();
+  }
+
+  private static String getTempMountBucketName() {
+    try {
+      return UserGroupInformation.getCurrentUser().getUserName();
+    } catch (IOException ex) {
+      return "undefined";  // TODO: Better idea?
+    }
   }
 }

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OFSPath.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OFSPath.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.fs.ozone;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.yetus.audience.InterfaceAudience;
@@ -76,7 +77,7 @@ class OFSPath {
         mountName = firstToken;
         // Future: retrieve volume and bucket from UserVolumeInfo
         volumeName = OFS_MOUNT_TMP_VOLUMENAME;
-        bucketName = getTempMountBucketName();
+        bucketName = getTempMountBucketName(null);
       } else if (numToken >= 2) {
         // Regular volume and bucket path
         volumeName = firstToken;
@@ -165,9 +166,20 @@ class OFSPath {
     return this.getBucketName().isEmpty() && !this.getVolumeName().isEmpty();
   }
 
-  private static String getTempMountBucketName() {
+  /**
+   * Get the bucket name of temp for given username.
+   * If input username String is null, will attempt to get user name from UGI.
+   * @param username Input user name String
+   * @return MD5 hash of username
+   */
+  @VisibleForTesting
+  static String getTempMountBucketName(String username) {
     try {
-      return UserGroupInformation.getCurrentUser().getUserName();
+      if (username == null) {
+        username = UserGroupInformation.getCurrentUser().getUserName();
+      }
+      // Hash the username to avoid invalid characters e.g. om/om@EXAMPLE.COM
+      return DigestUtils.md5Hex(username);
     } catch (IOException ex) {
       return "undefined";  // TODO: Better idea?
     }

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OFSPath.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OFSPath.java
@@ -52,8 +52,7 @@ class OFSPath {
   private String bucketName = "";
   private String mountName = "";
   private String keyName = "";
-  @VisibleForTesting
-  static final String OFS_MOUNT_NAME_TMP = "tmp";
+  private static final String OFS_MOUNT_NAME_TMP = "tmp";
   // Hard-code the volume name to tmp for the first implementation
   @VisibleForTesting
   static final String OFS_MOUNT_TMP_VOLUMENAME = "tmp";

--- a/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFSPath.java
+++ b/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFSPath.java
@@ -17,8 +17,11 @@
  */
 package org.apache.hadoop.fs.ozone;
 
+import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.io.IOException;
 
 /**
  * Testing basic functions of utility class OFSPath.
@@ -92,11 +95,17 @@ public class TestOFSPath {
 
   @Test
   public void testParsingMount() {
+    String username = "";
+    try {
+      username = UserGroupInformation.getCurrentUser().getUserName();
+    } catch (IOException ex) {
+      Assert.fail("Unable to get current user name.");
+    }
     // Mount only
     OFSPath ofsPath = new OFSPath("/tmp/");
-    // TODO: Subject to change in HDDS-2929.
-    Assert.assertEquals("tempVolume", ofsPath.getVolumeName());
-    Assert.assertEquals("tempBucket", ofsPath.getBucketName());
+    Assert.assertEquals(
+        OFSPath.OFS_MOUNT_TMP_VOLUMENAME, ofsPath.getVolumeName());
+    Assert.assertEquals(username, ofsPath.getBucketName());
     Assert.assertEquals("tmp", ofsPath.getMountName());
     Assert.assertEquals("", ofsPath.getKeyName());
     Assert.assertEquals("/tmp", ofsPath.getNonKeyPath());
@@ -104,9 +113,9 @@ public class TestOFSPath {
 
     // Mount with key
     ofsPath = new OFSPath("/tmp/key1");
-    // TODO: Subject to change in HDDS-2929.
-    Assert.assertEquals("tempVolume", ofsPath.getVolumeName());
-    Assert.assertEquals("tempBucket", ofsPath.getBucketName());
+    Assert.assertEquals(
+        OFSPath.OFS_MOUNT_TMP_VOLUMENAME, ofsPath.getVolumeName());
+    Assert.assertEquals(username, ofsPath.getBucketName());
     Assert.assertEquals("tmp", ofsPath.getMountName());
     Assert.assertEquals("key1", ofsPath.getKeyName());
     Assert.assertEquals("/tmp", ofsPath.getNonKeyPath());

--- a/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFSPath.java
+++ b/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFSPath.java
@@ -95,17 +95,12 @@ public class TestOFSPath {
 
   @Test
   public void testParsingMount() {
-    String username = "";
-    try {
-      username = UserGroupInformation.getCurrentUser().getUserName();
-    } catch (IOException ex) {
-      Assert.fail("Unable to get current user name.");
-    }
+    String bucketName = OFSPath.getTempMountBucketName(null);
     // Mount only
     OFSPath ofsPath = new OFSPath("/tmp/");
     Assert.assertEquals(
         OFSPath.OFS_MOUNT_TMP_VOLUMENAME, ofsPath.getVolumeName());
-    Assert.assertEquals(username, ofsPath.getBucketName());
+    Assert.assertEquals(bucketName, ofsPath.getBucketName());
     Assert.assertEquals("tmp", ofsPath.getMountName());
     Assert.assertEquals("", ofsPath.getKeyName());
     Assert.assertEquals("/tmp", ofsPath.getNonKeyPath());
@@ -115,7 +110,7 @@ public class TestOFSPath {
     ofsPath = new OFSPath("/tmp/key1");
     Assert.assertEquals(
         OFSPath.OFS_MOUNT_TMP_VOLUMENAME, ofsPath.getVolumeName());
-    Assert.assertEquals(username, ofsPath.getBucketName());
+    Assert.assertEquals(bucketName, ofsPath.getBucketName());
     Assert.assertEquals("tmp", ofsPath.getMountName());
     Assert.assertEquals("key1", ofsPath.getKeyName());
     Assert.assertEquals("/tmp", ofsPath.getNonKeyPath());

--- a/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFSPath.java
+++ b/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFSPath.java
@@ -17,11 +17,8 @@
  */
 package org.apache.hadoop.fs.ozone;
 
-import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.io.IOException;
 
 /**
  * Testing basic functions of utility class OFSPath.


### PR DESCRIPTION
Creating this PR in my own fork for demo and testing purpose.

https://issues.apache.org/jira/browse/HDDS-2929

1. An admin must create volume "tmp" with world access ACL before any user can use /tmp/
2. When a user is trying to write under /tmp/, a bucket with that user's name will be automatically created under volume "tmp"